### PR TITLE
fix filters_breadcrumbs on resize

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -7,6 +7,7 @@ import {
   onExerciseStartClick,
 } from './eventHandlers';
 import './search-input';
+import { resetExerciseHeader } from './header';
 
 window.matchMedia('(min-width: 768px)').addEventListener('change', e => {
   if (e.matches) {
@@ -22,6 +23,7 @@ window.matchMedia('(min-width: 768px)').addEventListener('change', e => {
 
   refs.searchForm.reset();
   refs.searchForm.classList.add('hidden');
+  resetExerciseHeader();
 
   rerender();
 });


### PR DESCRIPTION
When we are on exercices cards and resize window width (Mobile/Tablet) we do API request and set view back to Categories cards.

We also need to reset the breadcrumbs.